### PR TITLE
Initialize the ILThermo Entry wrapper class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ known-first-party = ["ilthermoml"]
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["ilthermopy", "pandas", "pytest", "semver"]
+module = ["ilthermopy", "pandas", "pytest", "pytest_mock", "semver"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ known-first-party = ["ilthermoml"]
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["pytest", "semver"]
+module = ["ilthermopy", "pandas", "pytest", "semver"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "ILThermoML"
 requires-python = ">=3.12,<3.13"
 dynamic = ["version"]
-dependencies = ["ilthermopy>=1.1.0"]
+dependencies = ["ilthermopy>=1.1.0", "pandas>=2.2.3"]
 
 [dependency-groups]
 local = ["ipykernel>=6.29.5", "pre-commit>=4.1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,6 @@ addopts = [
 ]
 python_files = ["test*.py"]
 testpaths = ["tests/"]
+
+[tool.coverage.report]
+exclude_also = ["if TYPE_CHECKING:"]

--- a/src/ilthermoml/dataset.py
+++ b/src/ilthermoml/dataset.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+__all__ = [
+    "Entry",
+]
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import ilthermopy as ilt
+
+from .exceptions import EntryError
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+@dataclass
+class Entry:
+    id: str
+    data: pd.DataFrame = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        try:
+            ilt_entry = ilt.GetEntry(self.id)
+        except Exception as e:
+            msg = f"failed to retrieve ILThermo entry {self.id!r}"
+
+            raise EntryError(msg) from e
+
+        self.data = ilt_entry.data.copy().rename(columns=ilt_entry.header)

--- a/src/ilthermoml/exceptions.py
+++ b/src/ilthermoml/exceptions.py
@@ -1,0 +1,12 @@
+__all__ = [
+    "EntryError",
+    "ILThermoMLException",
+]
+
+
+class ILThermoMLException(Exception):  # noqa: N818
+    pass
+
+
+class EntryError(ILThermoMLException):
+    pass

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ilthermoml.dataset import Entry
+from ilthermoml.exceptions import EntryError
+
+
+def test_retrive_entry() -> None:
+    # Arrange
+    kepte = pd.DataFrame(
+        {
+            "Temperature, K": {0: 298.15},
+            "Pressure, kPa": {0: 101.0},
+            "Viscosity, Pa&#8226;s => Liquid": {0: 0.255},
+            "Error of viscosity, Pa&#8226;s => Liquid": {0: 0.01},
+        }
+    )
+
+    entry = Entry("kepte")
+
+    # Assert
+    assert entry.data.equals(kepte)
+
+
+def test_failed_to_retrive_entry() -> None:
+    # Assert
+    with pytest.raises(EntryError):
+        Entry("invalidID")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import ilthermopy as ilt
 import pandas as pd
 import pytest
 
@@ -36,7 +35,6 @@ def test_entry_raises_entry_error_if_ilthermo_entry_cannot_be_retrieved(
     def mock_get_entry(code: str) -> Any:  # noqa: ANN401
         if code == "mock_id":
             raise MockError
-        return ilt.GetEntry(code)
 
     mocker.patch("ilthermopy.GetEntry", side_effect=mock_get_entry)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from unittest import mock
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import pytest
@@ -9,8 +9,11 @@ import pytest
 from ilthermoml.dataset import Entry
 from ilthermoml.exceptions import EntryError
 
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
-def test_retrive_entry() -> None:
+
+def test_retrive_entry(mocker: MockerFixture) -> None:
     # Arrange
     @dataclass()
     class MockIlthermopyEntry:
@@ -18,25 +21,24 @@ def test_retrive_entry() -> None:
         data: pd.DataFrame
 
     result = pd.DataFrame({"Replacement": [10]})
-
-    with mock.patch(
+    mock_get_entry = mocker.patch(
         "ilthermopy.GetEntry",
         return_value=MockIlthermopyEntry(
             header={"To_be_replaced": "Replacement"},
             data=pd.DataFrame({"To_be_replaced": [10]}),
         ),
-    ) as mock_get_entry:
-        entry = Entry("id")
+    )
+
+    # Act
+    entry = Entry("id")
 
     # Assert
     mock_get_entry.assert_called_once_with("id")
     assert entry.data.equals(result)
 
 
-def test_failed_to_retrive_entry() -> None:
+def test_failed_to_retrive_entry(mocker: MockerFixture) -> None:
     # Assert
-    with (
-        mock.patch("ilthermopy.GetEntry", mock.Mock(side_effect=Exception)),
-        pytest.raises(EntryError),
-    ):
+    mocker.patch("ilthermopy.GetEntry", mocker.Mock(side_effect=Exception))
+    with pytest.raises(EntryError):
         Entry("invalidID")

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,7 @@ name = "ilthermoml"
 source = { editable = "." }
 dependencies = [
     { name = "ilthermopy" },
+    { name = "pandas" },
 ]
 
 [package.dev-dependencies]
@@ -215,7 +216,10 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "ilthermopy", specifier = ">=1.1.0" }]
+requires-dist = [
+    { name = "ilthermopy", specifier = ">=1.1.0" },
+    { name = "pandas", specifier = ">=2.2.3" },
+]
 
 [package.metadata.requires-dev]
 local = [


### PR DESCRIPTION
Added a skeleton for the wrapper with a simple functionality (the `data` update).

Nevertheless, @chinise &mdash; try to cover it with tests as an exercise. @AdrianRacki &mdash; assist.

Resolves #42.