### PR TITLE
Add imports to the root module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ ignore = ["COM812", "D"]
 select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
+"**/__init__.py" = ["F403"]
 "**/test*.py" = ["S101"]
 
 [tool.ruff.lint.isort]

--- a/src/ilthermoml/__init__.py
+++ b/src/ilthermoml/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "0.1.0"
+
+from .dataset import *
+from .exceptions import *


### PR DESCRIPTION
This is just to simplify imports in projects using the library. I forgot to included it in #43.

I know that imports with `*` are generally considered as a bad practice. That is why I included `__all__` in `dataset` and `exceptions` modules.