### PR TITLE
Add environment variable support for joblib cache verbosity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .coverage
+.env*
 .ilt_cache/
 .mypy_cache/
 .pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ name = "ILThermoML"
 requires-python = ">=3.12,<3.13"
 dynamic = ["version"]
 dependencies = [
+  "environs>=14.1.1",
   "ilthermopy>=1.1.0",
   "joblib>=1.4.2",
   "pandas>=2.2.3",

--- a/src/ilthermoml/memory.py
+++ b/src/ilthermoml/memory.py
@@ -1,9 +1,6 @@
-import os
-
 from joblib import Memory
 
-ilt_memory = Memory(
-    location=".ilt_cache",
-    verbose=int(os.getenv("JOBLIB_CACHE_VERBOSITY", "0")),
-)
+from . import settings
+
+ilt_memory = Memory(location=".ilt_cache", verbose=settings.JOBLIB_CACHE_VERBOSITY)
 """Memory object for caching ILThermo data."""

--- a/src/ilthermoml/settings.py
+++ b/src/ilthermoml/settings.py
@@ -1,0 +1,8 @@
+from environs import env
+
+env.read_env()
+
+
+# Joblib
+
+JOBLIB_CACHE_VERBOSITY = env.int("JOBLIB_CACHE_VERBOSITY", default=0)

--- a/uv.lock
+++ b/uv.lock
@@ -153,6 +153,19 @@ wheels = [
 ]
 
 [[package]]
+name = "environs"
+version = "14.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/d3/e82bdbb8cc332e751f67a3f668c5d134d57f983497d9f3a59a375b6e8fd8/environs-14.1.1.tar.gz", hash = "sha256:03db7ee2d50ec697b68814cd175a3a05a7c7954804e4e419ca8b570dc5a835cf", size = 32050 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/1c/ab9752f02d32d981d647c05822be9ff93809be8953dacea2da2bec9a9de9/environs-14.1.1-py3-none-any.whl", hash = "sha256:45bc56f1d53bbc59d8dd69bba97377dd88ec28b8229d81cedbd455b21789445b", size = 15566 },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -192,6 +205,7 @@ wheels = [
 name = "ilthermoml"
 source = { editable = "." }
 dependencies = [
+    { name = "environs" },
     { name = "ilthermopy" },
     { name = "joblib" },
     { name = "pandas" },
@@ -222,6 +236,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "environs", specifier = ">=14.1.1" },
     { name = "ilthermopy", specifier = ">=1.1.0" },
     { name = "joblib", specifier = ">=1.4.2" },
     { name = "pandas", specifier = ">=2.2.3" },
@@ -361,6 +376,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/11/b56381fa6c3f4cc5d2cf54a7dbf98ad9aa0b339ef7a601d6053538b079a7/jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9", size = 87629 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/fb/108ecd1fe961941959ad0ee4e12ee7b8b1477247f30b1fdfd83ceaf017f0/jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409", size = 28965 },
+]
+
+[[package]]
+name = "marshmallow"
+version = "3.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/5e/5e53d26b42ab75491cda89b871dab9e97c840bf12c63ec58a1919710cd06/marshmallow-3.26.1.tar.gz", hash = "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6", size = 221825 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/75/51952c7b2d3873b44a0028b1bd26a25078c18f92f256608e8d1dc61b39fd/marshmallow-3.26.1-py3-none-any.whl", hash = "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c", size = 50878 },
 ]
 
 [[package]]
@@ -680,6 +707,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
 ]
 
 [[package]]


### PR DESCRIPTION
Refers to my discussion with @AdrianRacki in #75.

We all agree that we will evantually need more envs, so that configuring via `.env` file will be a must-have.

Why `environs`? Because it combines `python-decouple` and `python-dotenv`.
