### PR TITLE
Add ionic liquid handling to Entry and Dataset classes

### DIFF
--- a/src/ilthermoml/chemistry.py
+++ b/src/ilthermoml/chemistry.py
@@ -164,6 +164,9 @@ class Salt:
 class IonicLiquid(Salt):
     """Represents an ionic liquid."""
 
+    id: str | None = field(default=None, repr=False)
+    """The ILThermo identifier of the ionic liquid."""
+
     def __post_init__(self) -> None:
         super().__post_init__()
 

--- a/src/ilthermoml/dataset.py
+++ b/src/ilthermoml/dataset.py
@@ -56,13 +56,14 @@ class Entry:
 
             raise EntryError(msg)
 
-        if not (ionic_liquid_smiles := components[0].smiles):
+        ionic_liquid = components[0]
+        if not (ionic_liquid_smiles := ionic_liquid.smiles):
             msg = "could not retrieve ionic liquid SMILES from entry {self.id!r}"
 
             raise EntryError(msg)
 
         try:
-            self.ionic_liquid = IonicLiquid(ionic_liquid_smiles, id=self.id)
+            self.ionic_liquid = IonicLiquid(ionic_liquid_smiles, id=ionic_liquid.id)
         except ChemistryError as e:
             msg = (
                 f"could not instantiate IonicLiquid from SMILES "

--- a/src/ilthermoml/dataset.py
+++ b/src/ilthermoml/dataset.py
@@ -85,11 +85,6 @@ class Dataset(ABC):
     """The list of entries in the dataset."""
 
     @property
-    def ionic_liquids(self) -> list[IonicLiquid]:
-        """Return the list of ionic liquids in the dataset."""
-        return [entry.ionic_liquid for entry in self.entries]
-
-    @property
     def data(self) -> pd.DataFrame:
         """Concatenate and return the data from all entries in the dataset.
 

--- a/src/ilthermoml/dataset.py
+++ b/src/ilthermoml/dataset.py
@@ -86,6 +86,20 @@ class Dataset(ABC):
     """The list of entries in the dataset."""
 
     @property
+    def ionic_liquids(self) -> pd.DataFrame:
+        entries = self.entries
+
+        return (
+            pd.DataFrame(
+                {
+                    "ionic_liquid_id": [entry.ionic_liquid.id for entry in entries],
+                }
+            )
+            .drop_duplicates()
+            .set_index("ionic_liquid_id", drop=True)
+        )
+
+    @property
     def data(self) -> pd.DataFrame:
         """Concatenate and return the data from all entries in the dataset.
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -133,7 +133,7 @@ def test_entry_is_prepared_when_instantiated_with_dataset(
     mock_dataset.prepare_entry.assert_called_once()
 
 
-def test_entry_fails_when_no_smiles(
+def test_entry_raises_entry_error_when_no_smiles(
     mocker: MockerFixture,
 ) -> None:
     # Mock.
@@ -157,7 +157,7 @@ def test_entry_fails_when_no_smiles(
         Entry("mock_id")
 
 
-def test_entry_fails_when_smiles_invalid(
+def test_entry_raises_entry_error_when_smiles_invalid(
     mocker: MockerFixture,
 ) -> None:
     # Mock

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -170,7 +170,7 @@ def test_entry_raises_entry_error_when_smiles_invalid(
                         id="mock_id",
                         name="mock_name",
                     ),
-                    smiles="[Na+].[Cl-]",
+                    smiles="mock_invalid_smiles",
                 ),
             ],
         ),

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -17,7 +17,20 @@ def test_entry_attempts_to_retrieve_entry_from_ilthermo(
     mocker: MockerFixture,
 ) -> None:
     # Mock.
-    mock_get_entry = mocker.patch("ilthermoml.dataset.GetEntry")
+    mock_get_entry = mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            components=[
+                mocker.Mock(
+                    autospec=ILThermoPyCompound(
+                        id="mock_id",
+                        name="mock_name",
+                    ),
+                    smiles="CC[NH3+].[Cl-]",
+                ),
+            ],
+        ),
+    )
 
     # Act.
     Entry("mock_id")
@@ -77,7 +90,8 @@ def test_entry_updates_ilthermo_entry_data_columns_with_header(
                     autospec=ILThermoPyCompound(
                         id="mock_id",
                         name="mock_name",
-                    )
+                    ),
+                    smiles="CC[NH3+].[Cl-]",
                 ),
             ],
         ),
@@ -97,7 +111,20 @@ def test_entry_is_prepared_when_instantiated_with_dataset(
     mock_dataset = mocker.Mock()
 
     # Mock.
-    mocker.patch("ilthermoml.dataset.GetEntry")
+    mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            components=[
+                mocker.Mock(
+                    autospec=ILThermoPyCompound(
+                        id="mock_id",
+                        name="mock_name",
+                    ),
+                    smiles="CC[NH3+].[Cl-]",
+                ),
+            ],
+        ),
+    )
 
     # Act.
     Entry("mock_id", mock_dataset)
@@ -150,7 +177,20 @@ def test_dataset_populate_append_entries_with_ids_retrieved(
     dataset = TestDataset()
 
     # Mock.
-    mocker.patch("ilthermoml.dataset.GetEntry")
+    mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            components=[
+                mocker.Mock(
+                    autospec=ILThermoPyCompound(
+                        id="mock_id",
+                        name="mock_name",
+                    ),
+                    smiles="CC[NH3+].[Cl-]",
+                ),
+            ],
+        ),
+    )
 
     # Act.
     dataset.populate()
@@ -186,7 +226,8 @@ def test_dataset_populate_skips_entries_that_cannot_be_retrieved(
                     autospec=ILThermoPyCompound(
                         id="mock_id",
                         name="mock_name",
-                    )
+                    ),
+                    smiles="CC[NH3+].[Cl-]",
                 ),
             ],
         )
@@ -215,7 +256,8 @@ def test_dataset_data_returns_concatenated_entries(
                         autospec=ILThermoPyCompound(
                             id="mock_id_a",
                             name="mock_name_a",
-                        )
+                        ),
+                        smiles="CC[NH3+].[Cl-]",
                     ),
                 ],
             )
@@ -228,7 +270,8 @@ def test_dataset_data_returns_concatenated_entries(
                         autospec=ILThermoPyCompound(
                             id="mock_id_b",
                             name="mock_name_b",
-                        )
+                        ),
+                        smiles="CC[NH3+].[Cl-]",
                     ),
                 ],
             )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -133,6 +133,54 @@ def test_entry_is_prepared_when_instantiated_with_dataset(
     mock_dataset.prepare_entry.assert_called_once()
 
 
+def test_entry_fails_when_no_smiles(
+    mocker: MockerFixture,
+) -> None:
+    # Mock.
+    mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            components=[
+                mocker.Mock(
+                    autospec=ILThermoPyCompound(
+                        id="mock_id",
+                        name="mock_name",
+                    ),
+                    smiles=None,
+                ),
+            ],
+        ),
+    )
+
+    # Act & assert.
+    with pytest.raises(EntryError):
+        Entry("mock_id")
+
+
+def test_entry_fails_when_smiles_invalid(
+    mocker: MockerFixture,
+) -> None:
+    # Mock
+    mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            components=[
+                mocker.Mock(
+                    autospec=ILThermoPyCompound(
+                        id="mock_id",
+                        name="mock_name",
+                    ),
+                    smiles="[Na+].[Cl-]",
+                ),
+            ],
+        ),
+    )
+
+    # Act & assert.
+    with pytest.raises(EntryError):
+        Entry("mock_id")
+
+
 def test_dataset_populate_attempts_to_retrieve_entry_ids(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
Closes #61.

This is a follow-up for #79:

Key changes:

1. Ionic liquid is attempted to be resolved before data.
2. Ionic liquid ILThermo ID is added to `IonicLiquid` field.
3. Ionic liquid IDs are not added to the `Dataset.data`. Why? For now, let data contain only the actual "data" information. We will later extend the data property to provide a comprehensive table to be passed to ML models. This will be possible since ionic liquid associated with a certain data point can be easily resolved based on entry ID. In fact, upon these changes each `Entry` has `ionic_liquid` field.

Unfortunately, this breaks many tests due to the way we mocked `GetEntry` funcion...