### PR TITLE
Ionic liquids refactor

### DIFF
--- a/src/ilthermoml/chemistry.py
+++ b/src/ilthermoml/chemistry.py
@@ -29,7 +29,7 @@ class Molecule(ABC):
     smiles: str
     """The SMILES representation of the molecule."""
 
-    _rdkit_mol: Chem.Mol = field(init=False, repr=False)
+    _rdkit_mol: Chem.Mol = field(init=False, repr=False, compare=False)
     """The wrapped RDKit molecule object."""
 
     @abstractmethod

--- a/src/ilthermoml/dataset.py
+++ b/src/ilthermoml/dataset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ilthermoml.chemistry import IonicLiquid
+
 __all__ = [
     "Dataset",
     "Entry",
@@ -24,6 +26,9 @@ class Entry:
 
     id: str
     """The identifier of the entry."""
+
+    ionic_liquid: IonicLiquid = field(init=False, repr=False)
+    """The ionic liquid associated with the entry."""
 
     data: pd.DataFrame = field(init=False, repr=False)
     """The data associated with the entry."""
@@ -53,6 +58,19 @@ class Entry:
             raise EntryError(msg)
 
         self.data = ilt_entry.data.copy().rename(columns=ilt_entry.header)
+        self.ionic_liquid_id = ilt_entry.components[0].id
+
+        if smiles_error := ilt_entry.components[0].smiles_error:
+            msg = f"entry {self.id!r} has no smiles: {smiles_error}"
+
+            raise EntryError(msg)
+
+        try:
+            self.ionic_liquid = IonicLiquid(ilt_entry.components[0].smiles)
+        except Exception as e:
+            msg = f"invalid smiles {ilt_entry.components[0].smiles}"
+
+            raise EntryError(msg) from e
 
         if dataset:
             dataset.prepare_entry(self)

--- a/src/ilthermoml/dataset.py
+++ b/src/ilthermoml/dataset.py
@@ -95,10 +95,12 @@ class Dataset(ABC):
     ionic_liquids: list[IonicLiquid] = field(
         default_factory=list, init=False, repr=False
     )
+    """The list of ionic liquids in the dataset"""
 
     ions: list[Ion | Cation | Anion] = field(
         default_factory=list, init=False, repr=False
     )
+    """The list of ions in the dataset"""
 
     @property
     def data(self) -> pd.DataFrame:

--- a/src/ilthermoml/dataset.py
+++ b/src/ilthermoml/dataset.py
@@ -19,7 +19,7 @@ import ilthermopy as ilt
 import pandas as pd
 from tqdm import tqdm
 
-from .exceptions import DatasetError, EntryError
+from .exceptions import ChemistryError, DatasetError, EntryError
 from .memory import ilt_memory
 
 GetEntry = ilt_memory.cache(ilt.GetEntry)
@@ -72,7 +72,7 @@ class Entry:
 
         try:
             self.ionic_liquid = IonicLiquid(ilt_entry.components[0].smiles)
-        except Exception as e:
+        except ChemistryError as e:
             msg = f"invalid smiles {ilt_entry.components[0].smiles}"
 
             raise EntryError(msg) from e

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import pytest
-from ilthermopy.data_structs import Compound as ILThermoPyCompound
 
 from ilthermoml.dataset import Dataset, Entry
 from ilthermoml.exceptions import DatasetError, EntryError
@@ -17,7 +16,21 @@ def test_entry_attempts_to_retrieve_entry_from_ilthermo(
     mocker: MockerFixture,
 ) -> None:
     # Mock.
-    mock_get_entry = mocker.patch("ilthermoml.dataset.GetEntry")
+    mock_get_entry = mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            header={"V1": "mock_header"},
+            data=pd.DataFrame({"V1": []}),
+            components=[
+                mocker.Mock(
+                    id="mock_id",
+                    name="mock_name",
+                    smiles="C[NH3+].[Cl-]",
+                    smiles_error=None,
+                ),
+            ],
+        ),
+    )
 
     # Act.
     Entry("mock_id")
@@ -74,10 +87,10 @@ def test_entry_updates_ilthermo_entry_data_columns_with_header(
             data=pd.DataFrame({"V1": []}),
             components=[
                 mocker.Mock(
-                    autospec=ILThermoPyCompound(
-                        id="mock_id",
-                        name="mock_name",
-                    )
+                    id="mock_id",
+                    name="mock_name",
+                    smiles="C[NH3+].[Cl-]",
+                    smiles_error=None,
                 ),
             ],
         ),
@@ -97,7 +110,21 @@ def test_entry_is_prepared_when_instantiated_with_dataset(
     mock_dataset = mocker.Mock()
 
     # Mock.
-    mocker.patch("ilthermoml.dataset.GetEntry")
+    mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            header={"V1": "mock_header"},
+            data=pd.DataFrame({"V1": []}),
+            components=[
+                mocker.Mock(
+                    id="mock_id",
+                    name="mock_name",
+                    smiles="C[NH3+].[Cl-]",
+                    smiles_error=None,
+                ),
+            ],
+        ),
+    )
 
     # Act.
     Entry("mock_id", mock_dataset)
@@ -150,7 +177,21 @@ def test_dataset_populate_append_entries_with_ids_retrieved(
     dataset = TestDataset()
 
     # Mock.
-    mocker.patch("ilthermoml.dataset.GetEntry")
+    mocker.patch(
+        "ilthermoml.dataset.GetEntry",
+        return_value=mocker.Mock(
+            header={"V1": "mock_header"},
+            data=pd.DataFrame({"V1": []}),
+            components=[
+                mocker.Mock(
+                    id="mock_id",
+                    name="mock_name",
+                    smiles="C[NH3+].[Cl-]",
+                    smiles_error=None,
+                ),
+            ],
+        ),
+    )
 
     # Act.
     dataset.populate()
@@ -183,10 +224,10 @@ def test_dataset_populate_skips_entries_that_cannot_be_retrieved(
         return mocker.Mock(
             components=[
                 mocker.Mock(
-                    autospec=ILThermoPyCompound(
-                        id="mock_id",
-                        name="mock_name",
-                    )
+                    id="mock_id",
+                    name="mock_name",
+                    smiles="C[NH3+].[Cl-]",
+                    smiles_error=None,
                 ),
             ],
         )
@@ -212,10 +253,10 @@ def test_dataset_data_returns_concatenated_entries(
                 data=pd.DataFrame({"mock_header": [1, 2, 3]}),
                 components=[
                     mocker.Mock(
-                        autospec=ILThermoPyCompound(
-                            id="mock_id_a",
-                            name="mock_name_a",
-                        )
+                        id="mock_id_a",
+                        name="mock_name_a",
+                        smiles="C[NH3+].[Cl-]",
+                        smiles_error=None,
                     ),
                 ],
             )
@@ -225,10 +266,10 @@ def test_dataset_data_returns_concatenated_entries(
                 data=pd.DataFrame({"mock_header": [4, 5, 6]}),
                 components=[
                     mocker.Mock(
-                        autospec=ILThermoPyCompound(
-                            id="mock_id_b",
-                            name="mock_name_b",
-                        )
+                        id="mock_id_b",
+                        name="mock_name_b",
+                        smiles="CC[NH3+].[Cl-]",
+                        smiles_error=None,
                     ),
                 ],
             )


### PR DESCRIPTION
Closes #82

The ionic liquids and ions handling based on creating dataframes implemented previously in 9522d6a is not satisfactory when it comes to implementing calculating molecular descriptors, because it would require processing chemical information outside of chemistry submodule, or would necessitate new class in said submodule. With this new implementation we can simply implement it in `Molecule` class and then call it per instance.