### PR TITLE
Add padel featurizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "environs>=14.1.1",
   "ilthermopy>=1.1.0",
   "joblib>=1.4.2",
+  "padelpy>=0.1.16",
   "pandas>=2.2.3",
   "rdkit>=2024.9.5",
   "tqdm>=4.67.1",

--- a/src/ilthermoml/featurization.py
+++ b/src/ilthermoml/featurization.py
@@ -12,6 +12,8 @@ padel_calc_descriptors = ilt_memory.cache(padelpy.from_smiles)
 
 
 class MoleculeFeaturizer(ABC):
+    """Abstract class describing molecule featurizers."""
+
     def __call__(self, molecule: Molecule) -> dict[str, Any]:
         descriptors = self._featurize(molecule)
 
@@ -33,10 +35,14 @@ class MoleculeFeaturizer(ABC):
 
 
 class RDKitMoleculeFeaturizer(MoleculeFeaturizer):
+    """Moleclue featurizer class for calculating descriptors using RDKit."""
+
     def _featurize(self, molecule: Molecule) -> dict[str, Any]:
         return CalcMolDescriptors(molecule.rdkit_mol)  # type: ignore [no-untyped-call, no-any-return]
 
 
 class PadelMoleculeFeaturizer(MoleculeFeaturizer):
+    """Moleclue featurizer class for calculating descriptors using padel."""
+
     def _featurize(self, molecule: Molecule) -> dict[str, Any]:
         return padel_calc_descriptors(molecule.smiles)  # type: ignore [no-any-return]

--- a/src/ilthermoml/featurization.py
+++ b/src/ilthermoml/featurization.py
@@ -1,10 +1,14 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+import padelpy  # type: ignore [import-untyped]
 from rdkit.Chem.Descriptors import CalcMolDescriptors
 
 from .chemistry import Molecule
 from .exceptions import FeaturizerError
+from .memory import ilt_memory
+
+padel_calc_descriptors = ilt_memory.cache(padelpy.from_smiles)
 
 
 class MoleculeFeaturizer(ABC):
@@ -31,3 +35,8 @@ class MoleculeFeaturizer(ABC):
 class RDKitMoleculeFeaturizer(MoleculeFeaturizer):
     def _featurize(self, molecule: Molecule) -> dict[str, Any]:
         return CalcMolDescriptors(molecule.rdkit_mol)  # type: ignore [no-untyped-call, no-any-return]
+
+
+class PadelMoleculeFeaturizer(MoleculeFeaturizer):
+    def _featurize(self, molecule: Molecule) -> dict[str, Any]:
+        return padel_calc_descriptors(molecule.smiles)  # type: ignore [no-any-return]

--- a/src/ilthermoml/featurization.py
+++ b/src/ilthermoml/featurization.py
@@ -35,14 +35,14 @@ class MoleculeFeaturizer(ABC):
 
 
 class RDKitMoleculeFeaturizer(MoleculeFeaturizer):
-    """Moleclue featurizer class for calculating descriptors using RDKit."""
+    """Molecule featurizer class for calculating descriptors using RDKit."""
 
     def _featurize(self, molecule: Molecule) -> dict[str, Any]:
         return CalcMolDescriptors(molecule.rdkit_mol)  # type: ignore [no-untyped-call, no-any-return]
 
 
 class PadelMoleculeFeaturizer(MoleculeFeaturizer):
-    """Moleclue featurizer class for calculating descriptors using padel."""
+    """Molecule featurizer class for calculating descriptors using padel."""
 
     def _featurize(self, molecule: Molecule) -> dict[str, Any]:
         return padel_calc_descriptors(molecule.smiles)  # type: ignore [no-any-return]

--- a/tests/test_featurization.py
+++ b/tests/test_featurization.py
@@ -6,7 +6,11 @@ import pytest
 
 from ilthermoml.chemistry import Ion
 from ilthermoml.exceptions import FeaturizerError
-from ilthermoml.featurization import MoleculeFeaturizer, RDKitMoleculeFeaturizer
+from ilthermoml.featurization import (
+    MoleculeFeaturizer,
+    PadelMoleculeFeaturizer,
+    RDKitMoleculeFeaturizer,
+)
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -51,3 +55,23 @@ def test_rdkit_molecule_featurizer_attempts_calculating_descriptors(
 
     # Assert
     mock_calc_descriptors.assert_called_once_with(molecule.rdkit_mol)
+
+
+def test_padel_molecule_featurizer_attempts_calculating_descriptors(
+    mocker: MockerFixture,
+) -> None:
+    # Mock.
+    mock_calc_descriptors = mocker.patch(
+        "ilthermoml.featurization.padel_calc_descriptors",
+        return_value={"Test": "Test"},
+    )
+
+    # Arrange.
+    featurize = PadelMoleculeFeaturizer()
+    molecule = Ion("[Na+]")
+
+    # Act.
+    featurize(molecule)
+
+    # Assert
+    mock_calc_descriptors.assert_called_once_with(molecule.smiles)

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,7 @@ dependencies = [
     { name = "environs" },
     { name = "ilthermopy" },
     { name = "joblib" },
+    { name = "padelpy" },
     { name = "pandas" },
     { name = "rdkit" },
     { name = "tqdm" },
@@ -239,6 +240,7 @@ requires-dist = [
     { name = "environs", specifier = ">=14.1.1" },
     { name = "ilthermopy", specifier = ">=1.1.0" },
     { name = "joblib", specifier = ">=1.4.2" },
+    { name = "padelpy", specifier = ">=0.1.16" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "rdkit", specifier = ">=2024.9.5" },
     { name = "tqdm", specifier = ">=4.67.1" },
@@ -473,6 +475,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "padelpy"
+version = "0.1.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/19/6af9c17ce403cb372dd7ed75a5e6f00d0a7695ffaccd60584c33e9defebe/padelpy-0.1.16.tar.gz", hash = "sha256:bbe11fd93b3f7914f57b5dafbf83c5070161246fce4c626c1f394d73efabf394", size = 20873861 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/31/75879902fbdd5079a2177845a70c5d5de2915317c1187a83af3a857e70a8/padelpy-0.1.16-py3-none-any.whl", hash = "sha256:fb2814d48c498981c8ba10613e752e6ba856ccbd532aedcdc555154e87abf5b1", size = 20889833 },
 ]
 
 [[package]]


### PR DESCRIPTION
Padel takes a lot of time to calculate descriptors so joblib caching is included.