### PR TITLE
Change labels in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,19 @@ updates:
     schedule:
       interval: weekly
     labels:
-      - maintenance
+      - "type: maintenance"
+      - "priority: low"
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     labels:
-      - maintenance
+      - "type: maintenance"
+      - "priority: low"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     labels:
-      - maintenance
+      - "type: maintenance"
+      - "priority: low"


### PR DESCRIPTION
Closes #88

I also added `priority: low` tag to better integrate with new labeling system