### PR TITLE
Salt featurization

### DIFF
--- a/src/ilthermoml/featurization.py
+++ b/src/ilthermoml/featurization.py
@@ -45,4 +45,11 @@ class PadelMoleculeFeaturizer(MoleculeFeaturizer):
     """Molecule featurizer class for calculating descriptors using padel."""
 
     def _featurize(self, molecule: Molecule) -> dict[str, Any]:
-        return padel_calc_descriptors(molecule.smiles)  # type: ignore [no-any-return]
+        descriptors = padel_calc_descriptors(molecule.smiles)
+        for key, value in descriptors.items():
+            try:
+                descriptors[key] = float(value)
+            except ValueError:
+                continue
+
+        return descriptors  # type: ignore [no-any-return]

--- a/src/ilthermoml/featurization.py
+++ b/src/ilthermoml/featurization.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any
 
 import padelpy  # type: ignore [import-untyped]
 from rdkit.Chem.Descriptors import CalcMolDescriptors
 
-from .chemistry import Molecule
+from .chemistry import Molecule, Salt
 from .exceptions import FeaturizerError
 from .memory import ilt_memory
 
@@ -66,3 +67,33 @@ class CachingMoleculeFeaturizer(MoleculeFeaturizer):
         if molecule.smiles not in self._cache:
             self._cache[molecule.smiles] = self._inner_featurize(molecule)
         return self._cache[molecule.smiles]
+
+
+class SaltFeaturizer:
+    """Class for calculating salt descriptors."""
+
+    def __init__(
+        self,
+        combination_rule: Callable[[Any, Any], Any],
+        featurize: MoleculeFeaturizer,
+    ) -> None:
+        self.combination_rule = combination_rule
+        self.featurize = CachingMoleculeFeaturizer(featurize)
+
+    def __call__(self, salt: Salt) -> dict[str, Any]:
+        cation_features = self.featurize(salt.cation)
+        anion_features = self.featurize(salt.anion)
+
+        output_keys = set(list(cation_features) + list(anion_features))
+        output_values: list[Any] = []
+
+        for key in output_keys:
+            if not cation_features[key] or not anion_features[key]:
+                output_values.append(None)
+                continue
+
+            output_values.append(
+                self.combination_rule(cation_features[key], anion_features[key])
+            )
+
+        return dict(zip(output_keys, output_values, strict=True))

--- a/src/ilthermoml/featurization.py
+++ b/src/ilthermoml/featurization.py
@@ -53,3 +53,16 @@ class PadelMoleculeFeaturizer(MoleculeFeaturizer):
                 continue
 
         return descriptors  # type: ignore [no-any-return]
+
+
+class CachingMoleculeFeaturizer(MoleculeFeaturizer):
+    """Wrapper molecule featurizer class that caches calculated descriptors."""
+
+    def __init__(self, featurizer: MoleculeFeaturizer) -> None:
+        self._inner_featurize = featurizer
+        self._cache: dict[str, dict[str, Any]] = {}
+
+    def _featurize(self, molecule: Molecule) -> dict[str, Any]:
+        if molecule.smiles not in self._cache:
+            self._cache[molecule.smiles] = self._inner_featurize(molecule)
+        return self._cache[molecule.smiles]

--- a/tests/test_featurization.py
+++ b/tests/test_featurization.py
@@ -7,6 +7,7 @@ import pytest
 from ilthermoml.chemistry import Ion
 from ilthermoml.exceptions import FeaturizerError
 from ilthermoml.featurization import (
+    CachingMoleculeFeaturizer,
     MoleculeFeaturizer,
     PadelMoleculeFeaturizer,
     RDKitMoleculeFeaturizer,
@@ -99,3 +100,21 @@ def test_padel_molecule_featurizer_converts_output_to_floats(
     # Assert
     assert type(desctriptors["TestConvertable"]) is float
     assert type(desctriptors["TestUnconvertable"]) is str
+
+
+def test_cahing_molecule_featurizer_calls_inner_featurizer_only_once(
+    mocker: MockerFixture,
+) -> None:
+    # Spy.
+    spy_featurizer = mocker.spy(RDKitMoleculeFeaturizer(), "__call__")
+
+    # Arrange.
+    featurize = CachingMoleculeFeaturizer(spy_featurizer)
+    molecule = Ion("[Na+]")
+
+    # Act.
+    featurize(molecule)
+    featurize(molecule)
+
+    # Assert
+    spy_featurizer.assert_called_once_with(molecule)

--- a/tests/test_featurization.py
+++ b/tests/test_featurization.py
@@ -75,3 +75,27 @@ def test_padel_molecule_featurizer_attempts_calculating_descriptors(
 
     # Assert
     mock_calc_descriptors.assert_called_once_with(molecule.smiles)
+
+
+def test_padel_molecule_featurizer_converts_output_to_floats(
+    mocker: MockerFixture,
+) -> None:
+    # Mock.
+    mocker.patch(
+        "ilthermoml.featurization.padel_calc_descriptors",
+        return_value={
+            "TestConvertable": "0.15",
+            "TestUnconvertable": "Unconvertable",
+        },
+    )
+
+    # Arrange.
+    featurize = PadelMoleculeFeaturizer()
+    molecule = Ion("[Na+]")
+
+    # Act.
+    desctriptors = featurize(molecule)
+
+    # Assert
+    assert type(desctriptors["TestConvertable"]) is float
+    assert type(desctriptors["TestUnconvertable"]) is str


### PR DESCRIPTION
The implementation of `SaltFeaturizer` required a way of caching featurization results, so I added `CachingMoleculeFaturizer`.
Also it turns out that padelpy returns descriptor values as strings so I added a converter to floats.