### PR TITLE
Fix behaviour when featurizer returns None

### DIFF
--- a/src/ilthermoml/featurization.py
+++ b/src/ilthermoml/featurization.py
@@ -18,12 +18,7 @@ class MoleculeFeaturizer(ABC):
     def __call__(self, molecule: Molecule) -> dict[str, Any]:
         descriptors = self._featurize(molecule)
 
-        if any(
-            [
-                not descriptors,
-                all(not descriptor for descriptor in descriptors.values()),
-            ]
-        ):
+        if all(not descriptor for descriptor in descriptors.values()):
             msg = f"Unable to calculate descriptors for {molecule!r}"
 
             raise FeaturizerError(msg)


### PR DESCRIPTION
When implementing Molecule featurizer I added check to see if what specific featurizer returns is not None or whether any of the features were set.

I decided that the best way of resolving this would be to drop support of the None return and require implementations of the featurizers to raise errors instead.